### PR TITLE
feat: arsia support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
+# revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
 # revm = { version = "31.0.0", default-features = false }
-# revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-arsia", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-alpha", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
 # revm = { version = "31.0.0", default-features = false }
 # revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-# revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-arsia", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
+# revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
 ] }
 # revm = { version = "31.0.0", default-features = false }
 revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta.3", default-features = false }
-# revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"
@@ -68,5 +67,14 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
-[patch.crates-io]
-#revm = { git = "https://github.com/bluealloy/revm", rev = "e13b609fbbc80f9e5858255e4412db95c0cc6d12" }
+# [patch."https://github.com/mantle-xyz/revm"]
+# revm = { path = "../revm/crates/revm" }
+# revm-bytecode = { path = "../revm/crates/bytecode" }
+# revm-state = { path = "../revm/crates/state" }
+# revm-primitives = { path = "../revm/crates/primitives" }
+# revm-interpreter = { path = "../revm/crates/interpreter" }
+# revm-inspector = { path = "../revm/crates/inspector" }
+# revm-context = { path = "../revm/crates/context" }
+# revm-context-interface = { path = "../revm/crates/context/interface" }
+# revm-database = { path = "../revm/crates/database" }
+# revm-database-interface = { path = "../revm/crates/database/interface" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta.3", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta.1", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta.3", default-features = false }
 # revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
 
 anstyle = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.0-beta.1", default-features = false }
 # revm = { path = "/Users/sh001/Documents/codes/op-reth/revm/crates/revm", default-features = false }
 
 anstyle = { version = "1.0", optional = true }


### PR DESCRIPTION
## Summary

This PR merges `mantle-arsia` into `main` for `revm-inspectors`, primarily to align dependency configuration with the finalized Mantle REVM release.

## Changes

- Updated `revm` git dependency tag in `Cargo.toml` from `v2.2.0-alpha` to `v2.2.0`.
- Removed stale local-path dependency comment.
- Replaced the old `[patch.crates-io]` placeholder with a commented local workspace patch template for Mantle REVM crates.

## Scope

- File changes: 1 (`Cargo.toml`)
- Runtime/library logic changes: none (dependency configuration only)

## Validation

- Ran: `cargo check -p revm-inspectors`
- Result: passed

## Risk Assessment

Low risk. This is a dependency/tag alignment and config cleanup change with no direct behavioral code modifications in `revm-inspectors`.
