### PR TITLE
chore: pin revm to tag v98-mantle-arsia.1 (Arsia hotfix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 # revm = { version = "31.0.0", default-features = false }
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
Repoint revm from the fix branch to the released revm tag `v98-mantle-arsia.1` (revm PR #27 merged, commit c4a5004b). No functional change — only makes the revm dependency immutable for the reth `v1.9.3-mantle-arsia.2` release. `cargo check` green.

Pairs with mantle-xyz/evm#9. After this merges to main I'll tag it `v0.32.0-mantle-arsia.1`.